### PR TITLE
Added Discovery via Zyre. Refactor REQ/REP to use Zyre WHISPER.

### DIFF
--- a/mktl/mktlcoms.py
+++ b/mktl/mktlcoms.py
@@ -15,6 +15,7 @@ Typical usage:
 
     val, blob = coms.get("another.service.key")
 """
+import logging
 from logging import getLogger
 import itertools
 import zmq
@@ -25,10 +26,10 @@ import json
 import queue
 import time
 from typing import Callable, Dict, Optional, Any, List, Tuple, Union, Set
-
+from pyre import Pyre
 
 class MKTLMessage:
-    VALID_TYPES = {'get', 'set', 'ack', 'response', 'error', 'publish'}
+    VALID_TYPES = {'get', 'set', 'ack', 'response', 'config', 'error', 'publish'}
     REPLY_TYPES = {'ack', 'response', 'error'}
     REQUEST_TYPES = {'get', 'set'}
 
@@ -230,6 +231,12 @@ class MKTLMessage:
         """
         return self.msg_type in self.REQUEST_TYPES
 
+    def is_config(self):
+        """
+        Return True if the message type is in VALID_TYPES
+        """
+        return self.msg_type in self.VALID_TYPES
+
     def ack(self):
         """
         Send an immediate 'ack' response to the requester.
@@ -356,8 +363,8 @@ class MKTLComs:
     """
 
     def __init__(self, identity: Optional[str] = None, authoritative_keys: Optional[Dict[str, Callable]] = None,
-                 registry_addr: Optional[str] = None, shutdown_callback: Optional[Callable] = None,
-                 bind_addr: Optional[str] = None, pub_address: Optional[int] = None, start=False):
+                 shutdown_callback: Optional[Callable] = None, bind_addr: Optional[str] = None,
+                 pub_address: Optional[int] = None, group: Optional[str] = "MKTLGROUP", start=False):
         """
         Initialize a new mKTL communications object.
 
@@ -372,13 +379,18 @@ class MKTLComs:
         """
         logger = getLogger(__name__)
         logger.debug("Constructing MKTLComs instance...")
+        # Identity and Zyre group
         self.identity = identity or f'mktl-{uuid.uuid4().hex[:8]}'
+        self._group = group
         self.authoritative_keys = {}
-        self.registry_addr = registry_addr
 
         self._ctx = zmq.Context.instance()
         self._running = False
         self._threads = []
+
+        # Init Zyre
+        self._zyre_peer = Pyre(self.identity)
+        logger.debug(f"Initialized Zyre peer with identity={self.identity}")
 
         self._bind_address = None
         self._send_queue = queue.Queue()
@@ -390,8 +402,6 @@ class MKTLComs:
         if bind_addr is not None:
             self.bind(bind_addr, set_pub=pub_address is None)
 
-        self._router = None
-        self._dealer: Dict[str, zmq.Socket] = {}
         self._sub_socket = None
         self._sub_address = None
 
@@ -403,11 +413,7 @@ class MKTLComs:
 
         self._sub_callbacks: Dict[str, List[Callable]] = {}
         self._sub_listeners: Dict[str, List[MKTLSubscription]] = {}
-
         self._routing_table: Dict[str, Tuple[str, str]] = {}  # key -> (identity, address)
-        if registry_addr:
-            self._routing_table['registry.owner'] = ('registry', registry_addr)
-            self._routing_table['registry.config'] = ('registry', registry_addr)
 
         self._connected_addresses: dict[str, zmq.Socket] = {}
 
@@ -418,13 +424,13 @@ class MKTLComs:
                 self.register_key_handler(k, h)
         self._register_internal_handlers()
 
-        logger.info(f"MKTLComs created with identity={self.identity}, registry_addr={self.registry_addr}")
+        logger.info(f"MKTLComs created with identity={self.identity}")
 
         if start:
             self.start()
 
     def __repr__(self):
-        return f'MKTLComs(identity={self.identity}, registry_addr={self.registry_addr})'
+        return f'MKTLComs(identity={self.identity})'
 
     def _register_internal_handlers(self):
         """
@@ -451,58 +457,6 @@ class MKTLComs:
             logger.warning("Shutdown command received via mktl_control.")
             self._shutdown_callback()
 
-    def _send_registry_config(self):
-        """
-        Announce this node's authoritative keys to the registry service.
-
-        Encodes the identity, address, and known keys into a StoreConfig payload
-        and sends it as a `set` to `registry.config`.
-        """
-        logger = getLogger(__name__)
-        keys = list(self.authoritative_keys.keys())
-        user_keys = list(keys)
-        user_keys.remove(f'{self.identity}.mktl_control')
-        if not user_keys:
-            logger.debug("No authoritative keys to announce (besides mktl_control), will not register.")
-            return
-        logger.debug("Attempting to send registry config...")
-
-        payload = {'identity': self.identity,
-                   'address': self._bind_address,
-                   'keys': keys,
-                   }
-
-        self.set('registry.config', payload)
-
-    def _query_registry_owner(self, key: str) -> Optional[Tuple[str, str]]:
-        """
-        Query the registry for the owner of a specific key.
-
-        Sends a `get` request to `registry.owner` and expects a response
-        with `identity` and `address`.
-
-        Args:
-            key: The key to resolve.
-
-        Returns:
-            Tuple of (identity, address), or raises on failure.
-        """
-        logger = getLogger(__name__)
-        if not self.registry_addr:
-            logger.warning('Registry address not configured.')
-            return None
-
-        result = self.get('registry.owner', {'key': key})
-        identity = result.json_data.get('identity')
-        address = result.json_data.get('address')
-        if identity and address:
-            self._routing_table[key] = (identity, address)
-            logger.info(f"Registry resolution for {key}: identity={identity}, address={address}")
-            return identity, address
-        else:
-            logger.warning(f"Could not resolve owner for key={key}")
-            return None
-
     def _resolve_destination(self, key: str, destination: Optional[str]) -> str:
         """
         Determine the correct identity to route a request to.
@@ -521,13 +475,20 @@ class MKTLComs:
             logger.debug(f"Destination override provided for key={key}: {destination}")
             return destination
 
+        logger.debug(f"Current routing table: {self._routing_table}")
         identity, address = self._routing_table.get(key, (None, None))
-        if identity is None:
-            logger.debug(f"No local routing info for key={key}; querying registry.")
-            resolved = self._query_registry_owner(key)
-            if not resolved:
-                raise RuntimeError(f'Could not resolve destination for key: {key}')
-            identity, _ = resolved
+        if identity is not None:
+            logger.debug(f"Resolved destination for key={key}: {identity} with address={address}")
+        else:
+            logger.warning(f"No destination found in routing table for key={key}. Checking registry...")
+
+        # TODO: If we don't have the key mapped, we can ask for the current daemons to whisper and check again
+        # if identity is None:
+        #     logger.debug(f"No local routing info for key={key}; querying registry.")
+        #     resolved = self._query_registry_owner(key)
+        #     if not resolved:
+        #         raise RuntimeError(f'Could not resolve destination for key: {key}')
+        #     identity, _ = resolved
         return identity
 
     def _load_keys_for_prefix(self, prefix: str):
@@ -551,6 +512,7 @@ class MKTLComs:
 
         Handles request framing, timeout logic, and error propagation.
         """
+        #TODO: Need to make updates to send to a peer via Zyre
         logger = getLogger(__name__)
         if not self._running:
             logger.error("Cannot send request because MKTLComs is not started.")
@@ -560,7 +522,7 @@ class MKTLComs:
         logger.debug(f"Creating MKTLMessage for request type={msg_type}, key={key}")
         m = MKTLMessage(
             coms=self,
-            sender_id=self.identity.encode(),
+            sender_id=self.identity,
             msg_type=msg_type,
             req_id=req_id,
             key=key,
@@ -620,7 +582,7 @@ class MKTLComs:
 
     def _connect_for_key(self, key: str):
         """
-        Connects or reuses a DEALER socket for the provided key. If the socket for the
+        Connects or reuses for the provided key. If the socket for the
         key's address is not yet established, the method creates and connects a new
         socket. If the socket for the address exists but is not yet tied to the key,
         it associates the existing socket with the key. If the socket already exists
@@ -630,7 +592,7 @@ class MKTLComs:
             key (str): The routing key for which the socket connection is established.
 
         Returns:
-            bool: True iff a new connection was made.
+            bool: True if a new connection was made.
         """
         logger = getLogger(__name__)
         identity, address = self._routing_table[key]
@@ -652,90 +614,94 @@ class MKTLComs:
 
         return new_connection
 
-    def _serve_loop(self):
+    def _register_discovered_keys(self, peer_id: str, data: dict):
         """
-        Main server thread loop for receiving ROUTER messages.
-
-        Handles control-plane traffic: requests, responses, and registry lookups.
+        Register keys discovered in a config message's data field.
         """
         logger = getLogger(__name__)
-        logger.debug(f'Starting server loop for {self.identity} at {self._bind_address}')
-        self._router = self._ctx.socket(zmq.ROUTER)
-        self._router.setsockopt(zmq.IDENTITY, self.identity.encode())
-        self._router.setsockopt(zmq.ROUTER_MANDATORY, 1)
-        self._router.setsockopt(zmq.LINGER, 0)
-        self._router.monitor(f"inproc://{self.identity}-.monitor", zmq.EVENT_ACCEPTED)
-        mon_sock = self._ctx.socket(zmq.PAIR)
+        for key in data.keys():
+            self._routing_table[key] = (peer_id, None)
+            logger.info(f"Discovered config key '{key}' from peer '{peer_id}'")
 
-        if self._bind_address:
-            self._router.bind(self._bind_address)
-            logger.info(f'Response socket {self._router} created')
-            mon_sock.connect(f"inproc://{self.identity}-.monitor")
+    def _serve_loop(self):
+        """
+        Main loop for handling Zyre-based messaging: WHISPER, SHOUT, and peer tracking.
+        """
+        logger = getLogger(__name__)
+        logger.info(f"Zyre loop started. Listening in group '{self._group}'...")
 
+        # Start Zyre peer and join group
+        self._zyre_peer.join(self._group)
+        self._zyre_peer.start()
+
+        # Poll Zyre socket
         poller = zmq.Poller()
-        poller.register(self._router, zmq.POLLIN)
-        poller.register(mon_sock, zmq.POLLIN)
+        zyre_sock = self._zyre_peer.socket()
+        poller.register(zyre_sock, zmq.POLLIN)
 
         while self._running:
-
             events = dict(poller.poll(timeout=10))
 
-            if events.get(mon_sock, None) == zmq.POLLIN:
-                raw = mon_sock.recv_multipart()
-                # Convert raw monitor event frames into a python dict
-                evt = parse_monitor_message(raw)
-                if evt['event'] == zmq.EVENT_ACCEPTED:
-                    logger.info(f"New connection accepted from {evt}")
+            if events.get(zyre_sock) == zmq.POLLIN:
+                try:
+                    frames = self._zyre_peer.recv()
+                    if not frames or len(frames) < 2:
+                        continue
 
-            if events.get(self._router, None) == zmq.POLLIN:
-                msg = self._router.recv_multipart()
-                logger.debug(f'Received multipart message on {self._router}')
-                m, sender_id, err = MKTLMessage.try_parse(self, msg, received_by=self._router.identity)
-                if err:
-                    logger.warning(f'Received malformed message from {sender_id}: {err}. Ignoring')
-                else:
-                    assert m.is_request()
-                    logger.debug(f'Received message: {m}')
-                    try:
-                        m.respond(self._handle_message(m))
-                    except Exception as e:
-                        m.fail(e)
-                        logger.error(f'Exception while handling message: {e}', exc_info=True)
+                    event_type = frames[0].decode(errors='ignore')
+                    peer_id = frames[1].decode(errors='ignore')
+                    payload = frames[2:]
 
-            for sock in (s for s in self._connected_addresses.values() if events.get(s, None) == zmq.POLLIN):
-                msg = sock.recv_multipart()
-                logger.debug(f'Received multipart message on {sock}')
-                m, sender_id, err = MKTLMessage.try_parse(self, msg, received_by=sock.identity)
-                if err:
-                    logger.warning(f'Received malformed message from {sender_id}: {err}. Ignoring')
-                    continue
-                assert m.is_reply()
-                logger.debug(f'Received reply for request {m.req_id}')
-                with self._client_lock:
-                    if m.req_id in self._pending_replies:
-                        self._pending_replies[m.req_id] = m
+                    logger.debug(f"Received Zyre event: {event_type} from {peer_id}")
+
+                    if event_type == "WHISPER":
+                        m, sender_id, err = MKTLMessage.try_parse(self, payload, received_by=peer_id)
+                        if err:
+                            logger.warning(f"Malformed WHISPER from {sender_id}: {err}")
+                            continue
+
+                        if m.is_config():
+                            keys_data = m.json_data.get("keys", [])
+
+                            # Check if keys_data is a list before processing
+                            if isinstance(keys_data, list):
+                                for key in keys_data:
+                                    # Add to the routing table
+                                    self._routing_table[key] = (peer_id, None)
+                                    logger.info(f"Discovered config key '{key}' from peer '{peer_id}'")
+                        if m.is_request():
+                            logger.debug(f"Handling request: {m}")
+                            try:
+                                m.respond(self._handle_message(m))
+                            except Exception as e:
+                                m.fail(e)
+                                logger.error(f"Exception handling message: {e}", exc_info=True)
+
+                    elif event_type == "ENTER":
+                        logger.info(f"Peer entered: {peer_id}")
+                        self.announce_keys()
+
+                    elif event_type == "EXIT":
+                        logger.info(f"Peer exited: {peer_id}")
+                        # Clean up routing table entries
+                        self._routing_table = {
+                            k: v for k, v in self._routing_table.items() if v[1] != peer_id
+                        }
+
+                    elif event_type == "JOIN":
+                        logger.info(f"Peer {peer_id} joined group")
+
+                    elif event_type == "LEAVE":
+                        logger.info(f"Peer {peer_id} left group")
+
+                    elif event_type == "STOP":
+                        logger.info(f"Peer {peer_id} stopped")
+
                     else:
-                        logger.warning(f'Ignoring reply for unknown request: {m.req_id}')
+                        logger.debug(f"Unhandled Zyre event: {event_type}")
 
-            try:
-                while True:
-                    item = self._send_queue.get_nowait()
-                    frames = item.to_frames()
-                    if item.is_reply():
-                        logger.debug(f'Sending with response router: {item}') #\n' + '   ,\n'.join(map(str, frames)))
-                        self._router.send_multipart(frames)
-                    else:
-                        if self._connect_for_key(item.key):
-                            poller.register(self._dealer[item.key], zmq.POLLIN)
-                        logger.debug(f'Sending request to {self._dealer[item.key]}: {item}') #\n' + '   ,\n'.join(map(str, frames)))
-                        self._dealer[item.key].send_multipart(frames)
-            except queue.Empty:
-                pass
-
-        self._router.close()
-        for s in self._connected_addresses.values():
-            s.close()
-        self._dealer={}
+                except Exception as e:
+                    logger.error(f"Exception in serve loop: {e}", exc_info=True)
 
     def _listen_loop(self):
         """
@@ -859,6 +825,41 @@ class MKTLComs:
         getLogger(__name__).info(f"Connecting SUB socket to {address}")
         self._sub_address = address
 
+    def announce_keys(self):
+        """
+        Announce this node's authoritative keys to other peers via a WHISPER.
+        """
+        if not self._zyre_peer:
+            getLogger(__name__).warning("Zyre peer not initialized. Cannot announce keys.")
+            return
+
+        # Prepare the payload with the identity and keys of this node
+        payload = {
+            "keys": list(self.authoritative_keys.keys())
+        }
+
+        # Gen a unique request ID
+        request_id = uuid.uuid4().hex[:8].encode()
+
+        # Prepare the frame to be sent via WHISPER
+        frames = [
+            b'',
+            b'config',
+            request_id,
+            b'registry.announce',
+            json.dumps(payload).encode()
+        ]
+
+        # Get all peers in the group
+        # TODO: Filter based on prefix if provided
+        peers = self._zyre_peer.peers()
+        for peer in peers:
+            getLogger(__name__).info(f"Whispering keys to peer {peer}")
+            # Send the frame to each peer using WHISPER
+            self._zyre_peer.whisper(peer, frames)
+
+        getLogger(__name__).info(f"Whispered keys: {payload['keys']}")
+
     def register_key_handler(self, key: str, handler: Callable):
         """
         Register a key handler dynamically after MKTLComs has been created.
@@ -871,6 +872,7 @@ class MKTLComs:
         """
         self.authoritative_keys[key] = handler
         getLogger(__name__).debug(f"Registered key handler for {key}")
+        self.announce_keys()
 
     def on_key(self, key: str):
         """
@@ -922,9 +924,6 @@ class MKTLComs:
             logger.info('Starting listen loop thread')
             t_sub.start()
             self._threads.append(t_sub)
-
-        if self.registry_addr:
-            self._send_registry_config()
 
     def stop(self):
         """

--- a/tests/pyre_test.py
+++ b/tests/pyre_test.py
@@ -9,7 +9,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 def handle_adc_enabled(msg):
     logging.info(f"Handler received message: {msg}")
-    return {"message": "Handled adc.enabled"}
+    logging.info(f"Hello World!")
 
 
 def start_receiver(node_name: str, group_name: str):
@@ -48,7 +48,7 @@ def start_sender(node_name: str, group_name: str, message_data: dict, key: str):
     time.sleep(3)
 
     try:
-        response = node.get(key, message_data, timeout=5)
+        response = node.get(key, message_data, timeout=20)
         logging.info(f"{node_name} received response: {response}")
     except Exception as e:
         logging.error(f"{node_name} failed to get response: {e}")

--- a/tests/pyre_test.py
+++ b/tests/pyre_test.py
@@ -1,0 +1,79 @@
+import logging
+import time
+import threading
+from mktl.mktlcoms import MKTLComs
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+
+
+def handle_adc_enabled(msg):
+    logging.info(f"Handler received message: {msg}")
+    return {"message": "Handled adc.enabled"}
+
+
+def start_receiver(node_name: str, group_name: str):
+    """
+    Starts a MKTLComs node that will receive messages.
+    """
+    node = MKTLComs(
+        identity=node_name,
+        authoritative_keys={"adc.enabled": handle_adc_enabled},  # Handler is callable
+        group=group_name,
+        bind_addr=f"tcp://*:{5700 + hash(node_name) % 1000}",
+        pub_address=f"tcp://*:{5800 + hash(node_name) % 1000}",
+        start=True
+    )
+
+    # Announce the keys so the sender knows who owns what
+    node.announce_keys()
+
+    logging.info(f"{node_name} listening for messages...")
+    time.sleep(10)  # Keep the receiver running for a bit
+
+
+def start_sender(node_name: str, group_name: str, message_data: dict, key: str):
+    """
+    Starts a MKTLComs node and sends a `get` request using MKTLComs API.
+    """
+    node = MKTLComs(
+        identity=node_name,
+        group=group_name,
+        bind_addr=f"tcp://*:{5700 + hash(node_name) % 1000}",
+        pub_address=f"tcp://*:{5800 + hash(node_name) % 1000}",
+        start=True
+    )
+
+    # Wait for peer discovery and key announcements
+    time.sleep(3)
+
+    try:
+        response = node.get(key, message_data, timeout=5)
+        logging.info(f"{node_name} received response: {response}")
+    except Exception as e:
+        logging.error(f"{node_name} failed to get response: {e}")
+
+
+def run_test():
+    group_name = "TestGroup"
+    key = "adc.enabled"
+    message = {"message": "Hello from Peer1"}
+
+    # Start receiver first
+    receiver = threading.Thread(target=start_receiver, args=("Peer2", group_name))
+    receiver.start()
+
+    time.sleep(10)
+
+    # Then start a sender
+    sender = threading.Thread(target=start_sender, args=("Peer1", group_name, message, key))
+    sender.start()
+
+    sender.join()
+    receiver.join()
+
+    print("Test completed.")
+
+
+if __name__ == "__main__":
+    run_test()

--- a/tests/pyre_test.py
+++ b/tests/pyre_test.py
@@ -25,9 +25,6 @@ def start_receiver(node_name: str, group_name: str):
         start=True
     )
 
-    # Announce the keys so the sender knows who owns what
-    node.announce_keys()
-
     logging.info(f"{node_name} listening for messages...")
     time.sleep(10)  # Keep the receiver running for a bit
 


### PR DESCRIPTION
Example from test run

```
DEBUG:pyre.pyre_peer:Connecting to peer b8a1ee7f-e57e-415d-b0ab-ef0043bd3033 on endpoint tcp://10.8.17.8:55425
DEBUG:pyre.pyre_peer:Peer2 send HELLO to peer=notset sequence=1
DEBUG:pyre.pyre_peer:Connecting to peer 8534eb15-aced-4b8d-9dd9-90f7947842eb on endpoint tcp://10.8.17.8:55424
DEBUG:pyre.pyre_peer:Peer1 send HELLO to peer=notset sequence=1
DEBUG:pyre.pyre_peer:(Peer1) recv HELLO from peer=notset sequence=1
DEBUG:pyre.pyre_node:(Peer1) ENTER name=Peer2 endpoint=tcp://10.8.17.8:55424
DEBUG:mktl.mktlcoms:Received event frames: [b'ENTER', b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb', b'Peer2', b'{}', b'tcp://10.8.17.8:55424']
DEBUG:mktl.mktlcoms:Event name: ENTER
DEBUG:mktl.mktlcoms:Received Zyre event: ENTER from b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb'
INFO:mktl.mktlcoms:Peer entered group: b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb'
DEBUG:pyre.pyre_node:(Peer1) JOIN name=Peer2 group=TestGroup
DEBUG:mktl.mktlcoms:Received event frames: [b'JOIN', b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb', b'Peer2', b'TestGroup']
DEBUG:mktl.mktlcoms:Event name: JOIN
DEBUG:mktl.mktlcoms:Received Zyre event: JOIN from b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb'
INFO:mktl.mktlcoms:Peer b'\x854\xeb\x15\xac\xedK\x8d\x9d\xd9\x90\xf7\x94xB\xeb' joined group b'JOIN'
DEBUG:pyre.pyre_peer:(Peer2) recv HELLO from peer=notset sequence=1
DEBUG:pyre.pyre_node:(Peer2) ENTER name=Peer1 endpoint=tcp://10.8.17.8:55425
DEBUG:pyre.pyre_node:(Peer2) JOIN name=Peer1 group=TestGroup
DEBUG:mktl.mktlcoms:Received event frames: [b'ENTER', b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03', b'Peer1', b'{}', b'tcp://10.8.17.8:55425']
DEBUG:mktl.mktlcoms:Event name: ENTER
DEBUG:mktl.mktlcoms:Received Zyre event: ENTER from b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03'
INFO:mktl.mktlcoms:Peer entered group: b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03'
DEBUG:mktl.mktlcoms:Received event frames: [b'JOIN', b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03', b'Peer1', b'TestGroup']
DEBUG:mktl.mktlcoms:Event name: JOIN
DEBUG:mktl.mktlcoms:Received Zyre event: JOIN from b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03'
INFO:mktl.mktlcoms:Peer b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03' joined group b'JOIN'
INFO:root:Peer1 sending WHISPER to peer 8534eb15-aced-4b8d-9dd9-90f7947842eb
DEBUG:pyre.pyre_peer:Peer1 send WHISPER to peer=Peer2 sequence=2
DEBUG:pyre.pyre_peer:(Peer2) recv WHISPER from peer=Peer1 sequence=2
DEBUG:mktl.mktlcoms:Received event frames: [b'WHISPER', b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03', b'Peer1', b'', b'get', b'28b68bf5', b'adc.enabled', b'{"message": "Hello from Peer1"}']
DEBUG:mktl.mktlcoms:Event name: WHISPER
DEBUG:mktl.mktlcoms:Received Zyre event: WHISPER from b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03'
DEBUG:mktl.mktlcoms:Received WHISPER from b'\xb8\xa1\xee\x7f\xe5~A]\xb0\xab\xef\x00C\xbd03'
DEBUG:mktl.mktlcoms:Trying to parse frames
DEBUG:mktl.mktlcoms:Attempting to parse MKTLMessage from frames:
   b'Peer1',
   b'',
   b'get',
   b'28b68bf5',
   b'adc.enabled',
   b'{"message": "Hello from Peer1"}'
DEBUG:mktl.mktlcoms:MKTLMessage created: msg_type=get, key=adc.enabled, req_id=b'28b68bf5'
DEBUG:mktl.mktlcoms:Parsed frames into <MKTLMessage MKTLComs(identity=Peer2), b'Peer1', get, b'28b68bf5', adc.enabled, {'message': 'Hello from Peer1'}, None>
INFO:mktl.mktlcoms:Parsed WHISPER message: <MKTLMessage MKTLComs(identity=Peer2), b'Peer1', get, b'28b68bf5', adc.enabled, {'message': 'Hello from Peer1'}, None>
INFO:mktl.mktlcoms:Received whisper message: Hello from Peer1
```